### PR TITLE
增加了服务端缓存

### DIFF
--- a/evan-rpc-core/src/main/java/com/evan/evanrpc/RpcApplication.java
+++ b/evan-rpc-core/src/main/java/com/evan/evanrpc/RpcApplication.java
@@ -25,6 +25,9 @@ public class RpcApplication {
         Registry registry = RegistryFactory.getInstance(registryConfig.getRegistry());
         registry.init(registryConfig);
         log.info("rpc init, registry = {}", registryConfig);
+
+        // 创建并注册 ShutDownHook, JVM 退出的优雅停机
+        Runtime.getRuntime().addShutdownHook(new Thread(registry::destroy));
     }
 
     /**

--- a/evan-rpc-core/src/main/java/com/evan/evanrpc/registry/RegistryServiceCache.java
+++ b/evan-rpc-core/src/main/java/com/evan/evanrpc/registry/RegistryServiceCache.java
@@ -1,0 +1,35 @@
+package com.evan.evanrpc.registry;
+
+import com.evan.evanrpc.model.ServiceMetaInfo;
+
+import java.util.List;
+
+public class RegistryServiceCache {
+    /**
+     * 服务消费端缓存
+     */
+    List<ServiceMetaInfo> serviceCache;
+
+    /**
+     * 写缓存
+     * @param newServiceCache
+     */
+    void writeCache(List<ServiceMetaInfo> newServiceCache) {
+        this.serviceCache = newServiceCache;
+    }
+
+    /**
+     * 读缓存
+     * @return
+     */
+    List<ServiceMetaInfo> readCache() {
+        return this.serviceCache;
+    }
+
+    /**
+     * 清除缓存
+     */
+    void clearCache() {
+        this.serviceCache = null;
+    }
+}


### PR DESCRIPTION
服务消费者在发现服务的时候优先从缓存中查找，因为服务提供者列表一般来说不会发生很大的变化，所以这样做可以有效减少机器性能损耗